### PR TITLE
fix: fixed typo in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,8 @@ on:
 
 jobs:
   build:
-    runs-on: {{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
     strategy:
       matrix:
         os:


### PR DESCRIPTION
fixed a typo:

was:
    runs-on: {{ matrix.os }}

should be:
    runs-on: ${{ matrix.os }}